### PR TITLE
Update `macos` configs.

### DIFF
--- a/macos/.macos
+++ b/macos/.macos
@@ -16,8 +16,20 @@ sudo scutil --set HostName "horus"
 sudo scutil --set LocalHostName "horus"
 sudo defaults write /Library/Preferences/SystemConfiguration/com.apple.smb.server NetBIOSName -string "horus"
 
+# Finder: show hidden files by default
+defaults write com.apple.finder AppleShowAllFiles -bool true
+
+# Finder: show all filename extensions
+defaults write NSGlobalDomain AppleShowAllExtensions -bool true
+
+# Finder: show status bar
+defaults write com.apple.finder ShowStatusBar -bool true
+
 # Finder: show path bar
 defaults write com.apple.finder ShowPathbar -bool true
+
+# Show the ~/Library folder
+chflags nohidden ~/Library && xattr -d com.apple.FinderInfo ~/Library
 
 # Don’t automatically rearrange Spaces based on most recent use
 defaults write com.apple.dock mru-spaces -bool false


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced Finder preferences on macOS to show hidden files, filename extensions, status bar, path bar, and the `~/Library` folder.
  - Disabled automatic rearrangement of Spaces based on recent use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->